### PR TITLE
feat: dim screen when timer paused

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -660,7 +660,12 @@ export default function App() {
   const controlsAnchorTop = `calc(25vh - ${SIZE / 4}px)`;
 
   return (
-    <div className="relative" style={{ minHeight: "100vh" }}>
+    <motion.div
+      className="relative"
+      style={{ minHeight: "100vh" }}
+      animate={{ filter: isRunning ? "none" : "grayscale(1) blur(2px)", opacity: isRunning ? 1 : 0.6 }}
+      transition={{ duration: 0.3 }}
+    >
       {/* Base background */}
       <div className="absolute inset-0 -z-10" style={{ backgroundColor: isBreak ? "#ffffff" : "#000000" }} />
 
@@ -883,6 +888,6 @@ export default function App() {
           </div>
         </div>
       </div>
-    </div>
+    </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- visually dim and desaturate the interface when the timer is not running for clearer status feedback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68996937879c832a9ed45f9a9a967b05