### PR TITLE
feat: add theme picker

### DIFF
--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { themes, ThemeKey } from '../theme/themes';
+import { useTheme } from '../theme/ThemeContext';
+
+export default function SettingsDialog(): JSX.Element {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <div className="p-4">
+      <label htmlFor="theme" className="block mb-2 font-semibold">
+        Theme
+      </label>
+      <select
+        id="theme"
+        className="border rounded p-2"
+        value={theme}
+        onChange={(e) => setTheme(e.target.value as ThemeKey)}
+      >
+        {Object.entries(themes).map(([key, value]) => (
+          <option key={key} value={key}>
+            {value.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,5 +2,10 @@ import React from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
 import './index.css'   // <-- must be here
+import { ThemeProvider } from './theme/ThemeContext'
 
-createRoot(document.getElementById('root')).render(<App />)
+createRoot(document.getElementById('root')).render(
+  <ThemeProvider>
+    <App />
+  </ThemeProvider>
+)

--- a/src/theme/ThemeContext.tsx
+++ b/src/theme/ThemeContext.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, useEffect, useState, PropsWithChildren } from 'react';
+import { themes, ThemeKey } from './themes';
+
+type ThemeContextType = {
+  theme: ThemeKey;
+  setTheme: (t: ThemeKey) => void;
+};
+
+const ThemeContext = createContext<ThemeContextType>({
+  theme: 'default',
+  setTheme: () => {}
+});
+
+export function ThemeProvider({ children }: PropsWithChildren): JSX.Element {
+  const [theme, setTheme] = useState<ThemeKey>('default');
+
+  useEffect(() => {
+    const base = 'antialiased';
+    const cls = themes[theme].classes;
+    document.body.className = `${base} ${cls}`;
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/src/theme/themes.ts
+++ b/src/theme/themes.ts
@@ -1,0 +1,21 @@
+export type Theme = {
+  name: string;
+  classes: string;
+};
+
+export const themes: Record<string, Theme> = {
+  default: {
+    name: 'Default',
+    classes: 'bg-white text-gray-900'
+  },
+  highContrast: {
+    name: 'High Contrast',
+    classes: 'bg-black text-yellow-300'
+  },
+  pastel: {
+    name: 'Pastel',
+    classes: 'bg-pink-100 text-gray-800'
+  }
+};
+
+export type ThemeKey = keyof typeof themes;


### PR DESCRIPTION
## Summary
- add theme definitions
- provide theme context and apply tailwind classes
- add settings dialog with theme picker and wrap app with provider

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6899902f91e8832a977b3eeb082398ad