### PR TITLE
feat: toggle fullscreen with f key

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { motion, AnimatePresence, useAnimationFrame } from "framer-motion";
 
 /* ===================== Dial geometry ===================== */
@@ -455,13 +455,13 @@ export default function App() {
 
   // Fullscreen handling
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const toggleFullscreen = () => {
+  const toggleFullscreen = useCallback(() => {
     if (!document.fullscreenElement) {
       document.documentElement.requestFullscreen().catch(() => {});
     } else {
       document.exitFullscreen().catch(() => {});
     }
-  };
+  }, []);
   useEffect(() => {
     const onChange = () => setIsFullscreen(Boolean(document.fullscreenElement));
     document.addEventListener("fullscreenchange", onChange);
@@ -469,13 +469,20 @@ export default function App() {
   }, []);
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && document.fullscreenElement) {
+      const target = e.target as HTMLElement;
+      const tag = target.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable) return;
+      const key = e.key.toLowerCase();
+      if (key === "f") {
+        e.preventDefault();
+        toggleFullscreen();
+      } else if (key === "escape" && document.fullscreenElement) {
         document.exitFullscreen().catch(() => {});
       }
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, []);
+  }, [toggleFullscreen]);
 
   // --- Background chime reliability ---
   // Track absolute end time (ms) and whether we've already beeped for that timestamp.


### PR DESCRIPTION
## Summary
- Add keyboard shortcut `f` to toggle fullscreen, ignoring focused form fields
- Memoize fullscreen toggle handler with `useCallback`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689a5dde8e18832a9eb13d80e3c41e09