### PR TITLE
Increase audio volumes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -160,7 +160,7 @@ class SoundEngine {
   unlocked = false;
   // Track scheduled completion tones on the AudioContext timeline
   scheduled: OscillatorNode[] = [];
-  volume = 0.4;
+  volume = 0.6;
   muted = false;
 
   ensure() {
@@ -314,7 +314,7 @@ class SoundEngine {
         osc.type = "sine";
         osc.frequency.setValueAtTime(1000, start);
         g.gain.setValueAtTime(0, start);
-        g.gain.linearRampToValueAtTime(0.08, start + 0.004);
+        g.gain.linearRampToValueAtTime(0.12, start + 0.004);
         g.gain.exponentialRampToValueAtTime(
           Math.max(1e-4, 0.001),
           start + 0.05


### PR DESCRIPTION
## Summary
- Boost overall audio output by 50%
- Make countdown tick sound louder for final 5 seconds

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a137a68aac832ab8d816d4a1b96217