### PR TITLE
Fix alarm timing drift

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -656,12 +656,9 @@ export default function App() {
         sound.play("complete");
         beepedForRef.current = scheduledEndRef.current;
       }
-      // allow alarm to finish before scheduling the next chime
+      // schedule next chime immediately to avoid drift
       const nextNext: Mode = next === "focus" ? "break" : "focus";
-      setTimeout(
-        () => sound.scheduleCompleteIn(Math.max(0, nt - 2.4), nextNext),
-        2400
-      );
+      sound.scheduleCompleteIn(Math.max(0, nt - 2.4), nextNext);
       scheduledEndRef.current = newEnd;
       beepedForRef.current = null;
       scheduleBeepMarkIn(nt);


### PR DESCRIPTION
## Summary
- Schedule subsequent alarm chimes immediately instead of via `setTimeout`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68a143c2d2a4832a9fd52b8842a0c181