### PR TITLE
Fix chime drift causing double alarms

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -658,7 +658,7 @@ export default function App() {
       }
       // schedule next chime immediately to avoid drift
       const nextNext: Mode = next === "focus" ? "break" : "focus";
-      sound.scheduleCompleteIn(Math.max(0, nt - 2.4), nextNext);
+      sound.scheduleCompleteIn(nt, nextNext);
       scheduledEndRef.current = newEnd;
       beepedForRef.current = null;
       scheduleBeepMarkIn(nt);


### PR DESCRIPTION
## Summary
- schedule completion chime for entire session duration instead of early offset to keep audio and timer in sync

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a169984e58832a9b97ec29ca514873