### PR TITLE
Smooth timer progress animation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { motion, AnimatePresence, useAnimationFrame } from "framer-motion";
+import {
+  motion,
+  AnimatePresence,
+  useAnimationFrame,
+  useMotionValue,
+  animate,
+} from "framer-motion";
 
 /* ===================== Dial geometry ===================== */
 const SIZE = 440;
@@ -565,6 +571,15 @@ export default function App() {
   );
   const fracRemaining = clamp01(totalSec ? remaining / totalSec : 0);
 
+  const pathProgress = useMotionValue(fracRemaining);
+  useEffect(() => {
+    const controls = animate(pathProgress, Math.max(0.001, fracRemaining), {
+      duration: 1,
+      ease: "linear",
+    });
+    return controls.stop;
+  }, [fracRemaining, pathProgress]);
+
   useEffect(() => {
     if (!isRunning || endAt === null) return;
     const secLeft = Math.ceil(remaining);
@@ -898,9 +913,8 @@ export default function App() {
                   strokeLinecap="round"
                   fill="none"
                   filter="url(#ringGlow)"
-                  strokeDasharray={`${CIRC * Math.max(0.001, fracRemaining)} ${CIRC}`}
-                  animate={{ pathLength: Math.max(0.001, fracRemaining) }}
-                  transition={{ type: "tween", ease: "linear", duration: 0.05 }}
+                  strokeDasharray="0 1"
+                  style={{ pathLength: pathProgress }}
                 />
               </g>
             </svg>


### PR DESCRIPTION
## Summary
- animate progress ring with motion value for frame-by-frame smoothness

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a3bfb54e48832a8193b09dee808a59