### PR TITLE
Animate timer buttons with Framer Motion

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -767,6 +767,8 @@ export default function App() {
           style={{ pointerEvents: idle ? "none" : "auto" }}
           onMouseDown={sound.unlock}
           onTouchStart={sound.unlock}
+          whileHover={{ scale: 1.05, rotate: 2, transition: { duration: 0.15 } }}
+          whileTap={{ scale: 0.95, transition: { duration: 0.15 } }}
         >
           {isFullscreen ? <ExitFullscreenIcon /> : <FullscreenIcon />}
         </motion.button>
@@ -779,6 +781,8 @@ export default function App() {
           style={{ pointerEvents: idle ? "none" : "auto" }}
           onMouseDown={sound.unlock}
           onTouchStart={sound.unlock}
+          whileHover={{ scale: 1.05, rotate: 2, transition: { duration: 0.15 } }}
+          whileTap={{ scale: 0.95, transition: { duration: 0.15 } }}
         >
           {muted ? <MuteIcon /> : <VolumeIcon />}
         </motion.button>
@@ -840,7 +844,7 @@ export default function App() {
               className="flex items-center justify-center gap-3"
               style={{ pointerEvents: idle ? "none" : "auto" }}
             >
-              <button
+              <motion.button
                 aria-label={isRunning ? "Pause" : "Play"}
                 onClick={playPause}
                 className={btnCls}
@@ -848,10 +852,12 @@ export default function App() {
                 onTouchStart={sound.unlock}
                 onMouseUp={blurTarget}
                 onKeyUp={blurTarget}
+                whileHover={{ scale: 1.05, rotate: 2, transition: { duration: 0.15 } }}
+                whileTap={{ scale: 0.95, transition: { duration: 0.15 } }}
               >
                 {isRunning ? <PauseIcon /> : <PlayIcon />}
-              </button>
-              <button
+              </motion.button>
+              <motion.button
                 aria-label="Skip"
                 onClick={skip}
                 className={btnCls}
@@ -859,9 +865,11 @@ export default function App() {
                 onTouchStart={sound.unlock}
                 onMouseUp={blurTarget}
                 onKeyUp={blurTarget}
+                whileHover={{ scale: 1.05, rotate: 2, transition: { duration: 0.15 } }}
+                whileTap={{ scale: 0.95, transition: { duration: 0.15 } }}
               >
                 <SkipIcon />
-              </button>
+              </motion.button>
             </motion.div>
 
           </div>
@@ -949,7 +957,7 @@ export default function App() {
                   style={{ pointerEvents: idle ? "none" : "auto" }}
                   className="absolute right-0 top-full mt-1 flex items-center gap-1"
                 >
-                  <button
+                  <motion.button
                     aria-label="Reset timer"
                     onClick={resetTimer}
                     className={`${tinyBtnCls} [&>span]:rotate-[270deg] [&>span]:text-base inline-block`}
@@ -957,10 +965,12 @@ export default function App() {
                     onTouchStart={sound.unlock}
                     onMouseUp={blurTarget}
                     onKeyUp={blurTarget}
+                    whileHover={{ scale: 1.05, rotate: 2, transition: { duration: 0.15 } }}
+                    whileTap={{ scale: 0.95, transition: { duration: 0.15 } }}
                   >
                     <span className="inline-block">↺</span>
-                  </button>
-                  <button
+                  </motion.button>
+                  <motion.button
                     aria-label="Add 1 minute"
                     onClick={() => addTime(60)}
                     className={tinyBtnCls}
@@ -968,10 +978,12 @@ export default function App() {
                     onTouchStart={sound.unlock}
                     onMouseUp={blurTarget}
                     onKeyUp={blurTarget}
+                    whileHover={{ scale: 1.05, rotate: 2, transition: { duration: 0.15 } }}
+                    whileTap={{ scale: 0.95, transition: { duration: 0.15 } }}
                   >
                     +1
-                  </button>
-                  <button
+                  </motion.button>
+                  <motion.button
                     aria-label="Add 5 minutes"
                     onClick={() => addTime(300)}
                     className={tinyBtnCls}
@@ -979,9 +991,11 @@ export default function App() {
                     onTouchStart={sound.unlock}
                     onMouseUp={blurTarget}
                     onKeyUp={blurTarget}
+                    whileHover={{ scale: 1.05, rotate: 2, transition: { duration: 0.15 } }}
+                    whileTap={{ scale: 0.95, transition: { duration: 0.15 } }}
                   >
                     +5
-                  </button>
+                  </motion.button>
                 </motion.div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- replace static timer controls with `motion.button`
- add hover and tap scale/rotate animations to buttons for lively feedback

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a3e84980ec832abf74c9d358ecbed6