### PR TITLE
Add subtle tilt interaction for timer controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import {
   useAnimationFrame,
   useReducedMotion,
 } from "framer-motion";
+import TiltButton from "./TiltButton";
 
 /* ===================== Dial geometry ===================== */
 const SIZE = 440;
@@ -743,8 +744,8 @@ export default function App() {
     : "ring-1 ring-white/10 focus:ring-2 focus:ring-white/30";
   const surface = isBreak ? "bg-black/12 text-black backdrop-blur-md" : "bg-white/10 text-white backdrop-blur-md";
   const inputCls = `${CONTROL_W} ${CONTROL_H} leading-none rounded-xl px-2 text-center outline-none ${inputRing} ${surface} transition-colors`;
-  const btnCls = `rounded-xl ${CONTROL_W} ${CONTROL_H} flex items-center justify-center ${surface} select-none active:scale-95 transition-transform outline-none focus:outline-none focus:ring-0`;
-  const tinyBtnCls = `rounded-lg w-8 h-8 flex items-center justify-center text-xs ${surface} select-none active:scale-95 transition-transform outline-none focus:outline-none focus:ring-0`;
+  const btnCls = `rounded-xl ${CONTROL_W} ${CONTROL_H} flex items-center justify-center ${surface} select-none active:scale-95 transition-transform transform-gpu outline-none focus:outline-none focus:ring-0`;
+  const tinyBtnCls = `rounded-lg w-8 h-8 flex items-center justify-center text-xs ${surface} select-none active:scale-95 transition-transform transform-gpu outline-none focus:outline-none focus:ring-0`;
 
   // stack position
   const controlsAnchorTop = `calc(25vh - ${SIZE / 4}px)`;
@@ -860,7 +861,7 @@ export default function App() {
               className="flex items-center justify-center gap-3"
               style={{ pointerEvents: idle ? "none" : "auto" }}
             >
-              <button
+              <TiltButton
                 aria-label={isRunning ? "Pause" : "Play"}
                 onClick={playPause}
                 className={btnCls}
@@ -870,8 +871,8 @@ export default function App() {
                 onKeyUp={blurTarget}
               >
                 {isRunning ? <PauseIcon /> : <PlayIcon />}
-              </button>
-              <button
+              </TiltButton>
+              <TiltButton
                 aria-label="Skip"
                 onClick={skip}
                 className={btnCls}
@@ -881,7 +882,7 @@ export default function App() {
                 onKeyUp={blurTarget}
               >
                 <SkipIcon />
-              </button>
+              </TiltButton>
             </motion.div>
 
           </div>
@@ -969,7 +970,7 @@ export default function App() {
                   style={{ pointerEvents: idle ? "none" : "auto" }}
                   className="absolute right-0 top-full mt-1 flex items-center gap-1"
                 >
-                  <button
+                  <TiltButton
                     aria-label="Reset timer"
                     onClick={resetTimer}
                     className={`${tinyBtnCls} [&>span]:rotate-[270deg] [&>span]:text-base inline-block`}
@@ -979,8 +980,8 @@ export default function App() {
                     onKeyUp={blurTarget}
                   >
                     <span className="inline-block">↺</span>
-                  </button>
-                  <button
+                  </TiltButton>
+                  <TiltButton
                     aria-label="Add 1 minute"
                     onClick={() => addTime(60)}
                     className={tinyBtnCls}
@@ -990,8 +991,8 @@ export default function App() {
                     onKeyUp={blurTarget}
                   >
                     +1
-                  </button>
-                  <button
+                  </TiltButton>
+                  <TiltButton
                     aria-label="Add 5 minutes"
                     onClick={() => addTime(300)}
                     className={tinyBtnCls}
@@ -1001,7 +1002,7 @@ export default function App() {
                     onKeyUp={blurTarget}
                   >
                     +5
-                  </button>
+                  </TiltButton>
                 </motion.div>
               </div>
             </div>

--- a/src/TiltButton.tsx
+++ b/src/TiltButton.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+export type TiltButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  /** maximum tilt in degrees */
+  maxTilt?: number;
+};
+
+export default function TiltButton({
+  className = "",
+  onMouseMove,
+  onMouseLeave,
+  maxTilt = 4,
+  children,
+  ...rest
+}: TiltButtonProps) {
+  const handleMove = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = (e.clientX - rect.left) / rect.width - 0.5;
+    const y = (e.clientY - rect.top) / rect.height - 0.5;
+    const rx = (-y * maxTilt).toFixed(2);
+    const ry = (x * maxTilt).toFixed(2);
+    e.currentTarget.style.setProperty("--rx", `${rx}deg`);
+    e.currentTarget.style.setProperty("--ry", `${ry}deg`);
+    onMouseMove?.(e);
+  };
+
+  const handleLeave = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.currentTarget.style.setProperty("--rx", "0deg");
+    e.currentTarget.style.setProperty("--ry", "0deg");
+    onMouseLeave?.(e);
+  };
+
+  return (
+    <button
+      {...rest}
+      onMouseMove={handleMove}
+      onMouseLeave={handleLeave}
+      className={`tilt ${className}`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -48,3 +48,17 @@ input[type="number"] { -moz-appearance: textfield; }
   background: radial-gradient(65% 50% at 50% 70%, rgba(0,0,0,0.08), transparent 60%);
   pointer-events: none;
 }
+
+/* subtle 3D tilt for interactive buttons */
+.tilt {
+  transform:
+    perspective(600px)
+    rotateX(var(--rx, 0deg))
+    rotateY(var(--ry, 0deg))
+    translate(var(--tw-translate-x), var(--tw-translate-y))
+    rotate(var(--tw-rotate))
+    skewX(var(--tw-skew-x))
+    skewY(var(--tw-skew-y))
+    scaleX(var(--tw-scale-x))
+    scaleY(var(--tw-scale-y));
+}


### PR DESCRIPTION
## Summary
- Introduce reusable `TiltButton` component that tilts toward cursor for a subtle 3D hover effect
- Apply tilt and pressed interactions to play/pause, skip, reset, and time-adjust buttons
- Add global `.tilt` CSS leveraging Tailwind transform variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68a3ec1e761c832a9fb191fed9399a9e